### PR TITLE
media_rw permission for external storage

### DIFF
--- a/data/etc/platform.xml
+++ b/data/etc/platform.xml
@@ -65,6 +65,7 @@
     <permission name="android.permission.WRITE_EXTERNAL_STORAGE" >
         <group gid="sdcard_r" />
         <group gid="sdcard_rw" />
+        <group gid="media_rw" />
     </permission>
 
     <permission name="android.permission.ACCESS_ALL_EXTERNAL_STORAGE" >


### PR DESCRIPTION
This change is needed for Samsung devices with external sdcards formatted in FAT32. Enables the read/write access to such storage (otherwise read-only).
